### PR TITLE
fix reconnecting loop

### DIFF
--- a/flink-connector-mqtt/src/main/java/org/apache/flink/streaming/connectors/mqtt/MQTTSource.java
+++ b/flink-connector-mqtt/src/main/java/org/apache/flink/streaming/connectors/mqtt/MQTTSource.java
@@ -151,6 +151,10 @@ public class MQTTSource<OUT> extends MessageAcknowledgingSourceBase<OUT, String>
                             System.exit(1);
                         } catch (MqttException e) {
                             e.printStackTrace();
+                            if (e.getReasonCode() == MqttException.REASON_CODE_CLIENT_CLOSED) {
+                                LOG.error("Client closed connection, reconnecting is not possible, check your configuration/topics");
+                                System.exit(1);
+                            }
                             LOG.error("Could not get to MQTT broker, retry:" + e.getMessage());
                             try {
                                 Thread.sleep(3);


### PR DESCRIPTION
don't reconnect when other side closed connection
Can happen when e.g. the mqqt Topic is wrong, or another client already connected